### PR TITLE
Set up GitHub workflows to run basic checks via Danger 

### DIFF
--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -7,8 +7,7 @@ on:
     types: [opened, reopened, labeled, unlabeled]
 
 jobs:
-  danger_check_pr_labels:
-    name: Validate PR Labels
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Check Labels with DangerJS

--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check Labels with DangerJS
+      - name: Validate PR Labels
         uses: danger/danger-js@9.1.8
         with:
           args: "--dangerfile Automattic/peril-settings/org/pr/label.ts"

--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -1,0 +1,19 @@
+name: Validated PR Labels
+on:
+  pull_request:
+    # The restrictions on the types of pull_request event that can trigger this
+    # workflow is intentional. We only want to run label related checks on a
+    # new or reopened PR, or when its labels change.
+    types: [opened, reopened, labeled, unlabeled]
+
+jobs:
+  danger_check_pr_labels:
+    name: Validate PR Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Labels with DangerJS
+        uses: danger/danger-js@9.1.8
+        with:
+          args: "--dangerfile Automattic/peril-settings/org/pr/label.ts"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -7,8 +7,7 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  danger_check_pr_ios_specific:
-    name: iOS Sanity Checks
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Run sanity checks on the iOS project

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -1,4 +1,4 @@
-name: iOS Code Sanity Checks
+name: iOS Consistency Checks
 on:
   pull_request:
     # The restrictions on the types of pull_request event that can trigger this
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: Run sanity checks on the iOS project
+      - name: Run Consistency Checks
         uses: danger/danger-js@9.1.8
         with:
           args: "--dangerfile Automattic/peril-settings/org/pr/ios-macos.ts"

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -1,0 +1,19 @@
+name: iOS Code Sanity Checks
+on:
+  pull_request:
+    # The restrictions on the types of pull_request event that can trigger this
+    # workflow is intentional. We only want to run these sanity checks when the
+    # PR is opened or reopened, or its branch receives a push.
+    types: [opened, reopened, synchronize]
+
+jobs:
+  danger_check_pr_ios_specific:
+    name: iOS Sanity Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run sanity checks on the iOS project
+        uses: danger/danger-js@9.1.8
+        with:
+          args: "--dangerfile Automattic/peril-settings/org/pr/ios-macos.ts"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -9,6 +9,7 @@ extension BlogDetailsViewController {
             guard self?.blog.managedObjectContext != nil else {
                 return
             }
+            self?.refreshSiteIcon()
             self?.configureTableViewData()
             self?.reloadTableViewPreservingSelection()
             if let index = QuickStartTourGuide.find()?.currentElementInt(),

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -120,5 +120,6 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
 - (void)showPageList;
 - (void)showMediaLibrary;
 - (void)showStats;
+- (void)refreshSiteIcon;
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -339,6 +339,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self animateDeselectionInteractively];
         self.restorableSelectedIndexPath = nil;
     }
+    
+    self.navigationItem.title = self.blog.settings.name;
 
     [self.headerView setBlog:self.blog];
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1057,6 +1057,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAnalytics track:WPAnalyticsStatSiteSettingsSiteIconRemoved];
 }
 
+- (void)refreshSiteIcon {
+    [self.headerView refreshIconImage];
+}
+
 - (void)updateBlogIconWithMedia:(Media *)media
 {
     self.blog.settings.iconMediaID = media.mediaID;

--- a/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
@@ -59,7 +59,7 @@ class NewBlogDetailHeaderView: UIView {
             siteIconView.imageView.image = UIImage.siteIconPlaceholder
         }
 
-        //TODO: Refresh spotlight view
+        siteIconView.spotlightIsShown = QuickStartTourGuide.find()?.isCurrentElement(.siteIcon) == true
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
@@ -76,6 +76,9 @@ class NewBlogDetailHeaderView: UIView {
         self.init(frame: .zero)
 
         siteIconView.tapped = { [weak self] in
+            QuickStartTourGuide.find()?.visited(.siteIcon)
+            self?.siteIconView.spotlightIsShown = false
+
             self?.delegate?.siteIconTapped()
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/Detail Header/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Detail Header/SiteIconView.swift
@@ -5,17 +5,21 @@ class SiteIconView: UIView {
         static let borderRadius: CGFloat = 4
         static let imageRadius: CGFloat = 2
         static let imagePadding: CGFloat = 4
+        static let spotlightOffset: CGFloat = -8
     }
 
-    private let button: UIButton = {
-        let button = UIButton(frame: .zero)
-        button.backgroundColor = UIColor.secondaryButtonBackground
-        button.clipsToBounds = true
-        button.layer.borderColor = UIColor.secondaryButtonBorder.cgColor
-        button.layer.borderWidth = 1
-        button.layer.cornerRadius = Constants.borderRadius
-        return button
-    }()
+    /// Whether or not to show the spotlight animation to illustrate tapping the icon.
+    var spotlightIsShown: Bool = true {
+        didSet {
+            spotlightView.isHidden = !spotlightIsShown
+        }
+    }
+
+    /// A block to be called when the image button is tapped.
+    var tapped: (() -> Void)?
+
+    /// A block to be called when an image is dropped on to the view.
+    var dropped: (([UIImage]) -> Void)?
 
     let imageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
@@ -35,10 +39,25 @@ class SiteIconView: UIView {
         return indicatorView
     }()
 
-    var tapped: (() -> Void)?
-    var dropped: (([UIImage]) -> Void)?
-
     private var dropInteraction: UIDropInteraction?
+
+    private let button: UIButton = {
+        let button = UIButton(frame: .zero)
+        button.backgroundColor = UIColor.secondaryButtonBackground
+        button.clipsToBounds = true
+        button.layer.borderColor = UIColor.secondaryButtonBorder.cgColor
+        button.layer.borderWidth = 1
+        button.layer.cornerRadius = Constants.borderRadius
+        return button
+    }()
+
+    private let spotlightView: UIView = {
+        let spotlightView = QuickStartSpotlightView()
+        spotlightView.translatesAutoresizingMaskIntoConstraints = false
+
+        spotlightView.isHidden = true
+        return spotlightView
+    }()
 
     var allowsDropInteraction: Bool = false {
         didSet {
@@ -68,6 +87,14 @@ class SiteIconView: UIView {
         button.pinSubviewAtCenter(activityIndicator)
 
         addSubview(button)
+
+        addSubview(spotlightView)
+
+        NSLayoutConstraint.activate([
+            trailingAnchor.constraint(equalTo: spotlightView.trailingAnchor, constant: Constants.spotlightOffset),
+            bottomAnchor.constraint(equalTo: spotlightView.bottomAnchor, constant: Constants.spotlightOffset)
+        ])
+
         pinSubviewToAllEdges(button)
     }
 


### PR DESCRIPTION
This is the first step to implement https://github.com/wordpress-mobile/WordPress-iOS/issues/13366.

This adds a GitHub workflows that run the [shared Peril settings](https://github.com/Automattic/peril-settings) to:
-  [validate the PR's labels](https://github.com/Automattic/peril-settings/blob/f8b40cef2adae13967ddd55c3fd917c3b0f200b6/org/pr/labels.ts)
- [preform sanity checks on the iOS code](https://github.com/Automattic/peril-settings/blob/f8b40cef2adae13967ddd55c3fd917c3b0f200b6/org/pr/ios-macos.ts)

![screencapture-github-mokagio-WordPress-iOS-pull-6-2020-02-11-14_42_08](https://user-images.githubusercontent.com/1218433/74210103-8cfc0a00-4cde-11ea-94fb-8ef55472fca7.png)

This setup uses the [Danger GitHub Action](https://github.com/marketplace/actions/danger-js-action). I like it because we don't have to add anything to our repo in order to run Danger, but it comes with a time overhead on CI because the action needs to be fetched and built. 

Using the action is fine for now, I think, but we might want to do a performance comparison with a local Danger setup later on. It might be worth takin on the cost of maintaining a local setup if we can get a noticeably faster feedback loop for those opening the PR.

To test this, I'll be adding and removing labels to this PR as well as pushing (and then reverting) commits to trigger the sanity checks. If everything works, Danger will post warnings in those PRs via the GitHub Actions bot account. _The bot account is what I got wrong in my previous PRs. I finally figured it thanks to [the help of the Danger team](https://github.com/danger/danger-js/issues/856#issuecomment-584085043)_.