### PR TITLE
Add GitHub workflow to validate PR milestone via Danger

### DIFF
--- a/.github/workflows/danger-pr-milestone.yml
+++ b/.github/workflows/danger-pr-milestone.yml
@@ -4,7 +4,7 @@ on:
     # The restrictions on the types of pull_request event that can trigger this
     # workflow is intentional. We only want to run label related checks on a
     # new or reopened PR, or when its labels change.
-    types: [opened, reopened, milestoned, demilestoned]
+    types: [opened, reopened, labeled, unlabeled]
 
 jobs:
   check:

--- a/.github/workflows/danger-pr-milestone.yml
+++ b/.github/workflows/danger-pr-milestone.yml
@@ -1,0 +1,18 @@
+name: Validated PR Milestone
+on:
+  pull_request:
+    # The restrictions on the types of pull_request event that can trigger this
+    # workflow is intentional. We only want to run label related checks on a
+    # new or reopened PR, or when its labels change.
+    types: [opened, reopened, milestoned, demilestoned]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR Labels
+        uses: danger/danger-js@9.1.8
+        with:
+          args: "--dangerfile Automattic/peril-settings/org/pr/milestone.ts"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-pr-milestone.yml
+++ b/.github/workflows/danger-pr-milestone.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Validate PR Labels
         uses: danger/danger-js@9.1.8
         with:
-          args: "--dangerfile Automattic/peril-settings/org/pr/milestone.ts"
+          args: |
+            --dangerfile Automattic/peril-settings/org/pr/milestone.ts \
+            --id danger_milestone
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To test this, I'll be adding and removing a milestone to the PR.

Because this PR will be created without a milestone, I expect Danger to leave a comment about it.