### PR TITLE
Test - Different Danger ids

### DIFF
--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Validate PR Labels
         uses: danger/danger-js@9.1.8
         with:
-          args: "--dangerfile Automattic/peril-settings/org/pr/label.ts"
+          args: |
+            --dangerfile Automattic/peril-settings/org/pr/label.ts \
+            --id danger_labels
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Run Consistency Checks
         uses: danger/danger-js@9.1.8
         with:
-          args: "--dangerfile Automattic/peril-settings/org/pr/ios-macos.ts"
+          args: |
+            --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
+            --id danger_prs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add id parameter to the Dangers, so they don't cancel each other.

I saw a PR where one Danger comment disappeared after another one was added.