### PR TITLE
Test - Same Danger Ids

### DIFF
--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           args: |
             --dangerfile Automattic/peril-settings/org/pr/label.ts \
-            --id danger_labels
+            --id danger_id_same
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Validate PR Labels
         uses: danger/danger-js@9.1.8
         with:
-          args: "--dangerfile Automattic/peril-settings/org/pr/label.ts"
+          args: |
+            --dangerfile Automattic/peril-settings/org/pr/label.ts \
+            --id danger_labels
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           args: |
             --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
-            --id danger_prs
+            --id danger_id_same
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Run Consistency Checks
         uses: danger/danger-js@9.1.8
         with:
-          args: "--dangerfile Automattic/peril-settings/org/pr/ios-macos.ts"
+          args: |
+            --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
+            --id danger_prs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,9 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.13'
+    # pod 'WordPressShared', '~> 1.8.13'
+    # Use SHA to test Danger warning
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => 'efe5a065f3ace331353595ef85eef502baa23497'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'


### PR DESCRIPTION
If Danger is smart enough to not remove whole comments, this PR will have a message with two warnings:

- No labels
- A commit reference in the `Podfile`

---

**Update.** It seems Danger isn't smart enough.

![screencapture-github-mokagio-WordPress-iOS-pull-14-2020-02-14-15_10_37](https://user-images.githubusercontent.com/1218433/74500813-3d1a7e80-4f3c-11ea-9e93-3714d113459d.png)

_I'm actually going to open a new PR for this, and record the screen. I originally saw the labels warning, then reloaded the page and the other warning appeared._