### PR TITLE
Test - Different Danger ids

### DIFF
--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Validate PR Labels
         uses: danger/danger-js@9.1.8
         with:
-          args: "--dangerfile Automattic/peril-settings/org/pr/label.ts"
+          args: |
+            --dangerfile Automattic/peril-settings/org/pr/label.ts \
+            --id danger_labels
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Run Consistency Checks
         uses: danger/danger-js@9.1.8
         with:
-          args: "--dangerfile Automattic/peril-settings/org/pr/ios-macos.ts"
+          args: |
+            --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
+            --id danger_prs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,9 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.13'
+    # pod 'WordPressShared', '~> 1.8.13'
+    # Use SHA to test Danger warning
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => 'efe5a065f3ace331353595ef85eef502baa23497'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'


### PR DESCRIPTION
#14 seems to point out that Danger isn't smart enough to edit a comment's body when new warnings come in, but deletes the whole comment instead.

In this PR we set different ids for the different Danger runs. If everything works, we'll have two comments:

- No labels
- A commit reference in the Podfile