### PR TITLE
Test - Danger removes previous comments instead of editing

### DIFF
--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           args: |
             --dangerfile Automattic/peril-settings/org/pr/label.ts \
-            --id danger_labels
+            --id danger_id_same
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Validate PR Labels
         uses: danger/danger-js@9.1.8
         with:
-          args: "--dangerfile Automattic/peril-settings/org/pr/label.ts"
+          args: |
+            --dangerfile Automattic/peril-settings/org/pr/label.ts \
+            --id danger_labels
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           args: |
             --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
-            --id danger_prs
+            --id danger_id_same
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Run Consistency Checks
         uses: danger/danger-js@9.1.8
         with:
-          args: "--dangerfile Automattic/peril-settings/org/pr/ios-macos.ts"
+          args: |
+            --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
+            --id danger_prs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,9 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.13'
+    # pod 'WordPressShared', '~> 1.8.13'
+    # Use SHA to test Danger warning
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => 'efe5a065f3ace331353595ef85eef502baa23497'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'


### PR DESCRIPTION
It seems Danger doesn't have a way to understand which warnings should be kept in the comment and which should be removed. What happens is that when a new Danger run posts to the PR, it deletes the previous comment.

This PR demonstrates it.

We have two different `danger ci` running at more or less the same time. One will produce a warning about missing labels, the other a failure because there's a commit reference in the `Podfile`. Only one of those comments will remain in the PR.