### PR TITLE
Add GitHub workflow step to check PRs' milestone with Danger

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -5,12 +5,23 @@ on:
     # when the labels change, not only when a PR is opened/reopened or changes
     # are pushed to it.
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  # In order to validate the milestone, we need to listen for the event on the
+  # issue, as there's no event for milestones in PRs –GitHub PRs are a special
+  # kind of issue. Un
+  issues:
+    types: [milestoned, demilestoned]
 
 jobs:
   danger:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    if:
+      # One of the checks we run is for milestones, but the event that triggers
+      # it is for issues. In order to run this workflow only for PRs, we need
+      # to check the context to see if this was triggered by a PR or a plain
+      # issue.
+      github.event.pull_request != null || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@v2
 
@@ -45,3 +56,9 @@ jobs:
           yarn run danger ci \
             --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
             --id consistency_checks
+
+      - name: Validate Milestone
+        run: |
+          yarn run danger ci \
+            --dangerfile Automattic/peril-settings/org/pr/milestone.ts \
+            --id milestone


### PR DESCRIPTION
_Note, I based this PR off `danger-all-in-one-workflow-ready-for-trunk ` (https://github.com/wordpress-mobile/WordPress-iOS/pull/13535) to make it easier to review. I won't change the base branch or open a PR against trunk till the rest of the work has been merged._

---

Follows up on the https://github.com/wordpress-mobile/WordPress-iOS/issues/13366 work by migrating the milestone check to Danger + GitHub workflow (see [`milestone.ts`](https://github.com/Automattic/peril-settings/blob/5d22258ca46c3649f2cb863cfac2d16f12c4cba0/org/pr/milestone.ts)).

<img width="946" alt="Screen Shot 2020-02-24 at 14 27 21" src="https://user-images.githubusercontent.com/1218433/75127173-ce92a900-5711-11ea-8bc9-7a39ddb719dc.png">

Unfortunately, we cannot test whether the workflow is triggered when the milestone on the PR changes until the code is on the main branch of the repo. **I made a [demo repo](https://github.com/mokagio/github-action-milestone-workflow-example) with the code on the main branch for you to play with 👉 https://github.com/mokagio/github-action-milestone-workflow-example**.